### PR TITLE
feat(widget): add bottom nav bar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:kai_friends_app/widgets/app_bar.dart';
 
 void main() {
   runApp(const MyApp());
@@ -110,6 +111,7 @@ class _MyHomePageState extends State<MyHomePage> {
         tooltip: 'Increment',
         child: const Icon(Icons.add),
       ), // This trailing comma makes auto-formatting nicer for build methods.
+      bottomNavigationBar: BottomNavBar(),
     );
   }
 }

--- a/lib/widgets/app_bar.dart
+++ b/lib/widgets/app_bar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 class BottomNavBar extends StatelessWidget {
+  final accentColor = const Color(0xFFE73700);
   @override
   Widget build(BuildContext context) {
     return BottomNavigationBar(
@@ -25,7 +26,7 @@ class BottomNavBar extends StatelessWidget {
       currentIndex: 0,
       type: BottomNavigationBarType.fixed,
       unselectedItemColor: Colors.grey[500],
-      selectedItemColor: Colors.amber[800],
+      selectedItemColor: accentColor,
       showUnselectedLabels: true,
     );
   }

--- a/lib/widgets/app_bar.dart
+++ b/lib/widgets/app_bar.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class BottomNavBar extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return BottomNavigationBar(
+      items: const <BottomNavigationBarItem>[
+        BottomNavigationBarItem(
+          icon: Icon(Icons.search_rounded),
+          label: '친구 찾기',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.send_rounded),
+          label: '받은 신청',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.people_alt_rounded),
+          label: '친구 목록',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.settings),
+          label: '설정',
+        ),
+      ],
+      currentIndex: 0,
+      type: BottomNavigationBarType.fixed,
+      unselectedItemColor: Colors.grey[500],
+      selectedItemColor: Colors.amber[800],
+      showUnselectedLabels: true,
+    );
+  }
+}


### PR DESCRIPTION
Bottom Navigation Bar 추가 방법:
```
import 'package:kai_friends_app/widgets/app_bar.dart';

Scaffold (
    <생략>
    bottomNavigationBar: BottomNavBar(),
)
```

<img width="368" alt="Screen Shot 2022-01-26 at 2 20 11 PM" src="https://user-images.githubusercontent.com/48045424/151108124-946489ac-aae4-47b8-87b8-e9d283c6c6cb.png">